### PR TITLE
Correction du texte de survol de l’icône des saisons sur la page de résultat de recherche avancée

### DIFF
--- a/components/crags/CragsTable.vue
+++ b/components/crags/CragsTable.vue
@@ -28,7 +28,7 @@
               {{ mdiWalk }}
             </v-icon>
           </th>
-          <th class="text-center" :title="$t('components.cragsTable.approachTimeTitle')">
+          <th class="text-center" :title="$t('components.cragsTable.favorableSeasonsTitle')">
             <v-icon small>
               {{ mdiLeafMaple }}
             </v-icon>

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -902,6 +902,7 @@ export default {
       lines: 'Lines',
       orientations: 'Orientations',
       approachTimeTitle: 'Minutes walking time',
+      favorableSeasonsTitle: 'Favorable seasons',
       distanceTitle: 'Distance from the location',
       season: 'Favorable seasons'
     },

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -902,6 +902,7 @@ export default {
       lines: 'Lignes',
       orientations: 'Orientations',
       approachTimeTitle: "Minutes de marche d'approche",
+      favorableSeasonsTitle: 'Saisons favorables',
       distanceTitle: 'Distance du lieux cherché',
       season: 'Saison favorables'
     },


### PR DESCRIPTION
Sur la page de résultat de recherche avancée, il y a un tableau en bas avec les résultats. L’entête de la colonne des saisons (icône en forme de feuille d'érable) affichait le temps d'approche quand elle était survoler par le curseur. J'ai donc changé le texte et rajouter la description qui me semblait approprié en français et en anglais (respectivement "Saisons favorables" et "Favorable seasons").

PS: Je viens de découvrir le projet, c'est vraiment trop bien, je ne vais pas tarder à l'utiliser pour mes prochaines sorties!