### PR TITLE
Correction impossibilité de donner une nouvelle localisation à un secteur

### DIFF
--- a/components/cragSectors/forms/CragSectorForm.vue
+++ b/components/cragSectors/forms/CragSectorForm.vue
@@ -22,8 +22,8 @@
         <map-input
           v-if="setLocalization"
           v-model="localization"
-          :default-latitude="data.latitude || crag.latitude"
-          :default-longitude="data.longitude || crag.longitude"
+          :default-latitude="data.latitude"
+          :default-longitude="data.longitude"
           :geo-jsons="geoJsons"
           :default-zoom="15"
           style-map="outdoor"


### PR DESCRIPTION
En lien avec #52 
Le map-input de CragSectorForm cherchait à utiliser crag.latitude si data.latitude n'existait pas. Cependant, crag était nul. Ce changement retire crag.latitude et crag.longitude et laisse à map-input la gestion des valeurs nulles.