### PR TITLE
Correction de l'impossibilité de changer de fond de carte sur la page de modification des approches

### DIFF
--- a/components/approaches/forms/ApproachForm.vue
+++ b/components/approaches/forms/ApproachForm.vue
@@ -42,7 +42,11 @@
 
             <!-- Layer Selector -->
             <l-control position="topright">
-              <leaflet-layer-selector v-model="layerIndex" map-style="outdoor" />
+              <leaflet-layer-selector
+                ref="leafletLayerSelector"
+                v-model="layerIndex"
+                :layers="layers"
+              />
             </l-control>
 
             <l-tile-layer
@@ -147,16 +151,19 @@ export default {
       layerIndex: 0,
       layers: [
         {
+          title: 'relief',
           name: 'Eseri Topo',
           url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
           attribution: '&copy; <a href="https://www.esrifrance.fr/">Esri</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'
         },
         {
+          title: 'satellite',
           name: 'Eseri Satelite',
           url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
           attribution: '&copy; <a href="https://www.esrifrance.fr/">Esri</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'
         },
         {
+          title: 'detailedRelief',
           name: 'CyclOSM',
           url: 'https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
           attribution: '&copy; <a href="https://www.cyclosm.org">CyclOSM</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'

--- a/components/crags/forms/CragMapEditForm.vue
+++ b/components/crags/forms/CragMapEditForm.vue
@@ -304,7 +304,11 @@
 
         <!-- Layer Selector -->
         <l-control position="topright">
-          <leaflet-layer-selector v-model="layerIndex" map-style="outdoor" />
+          <leaflet-layer-selector
+            ref="leafletLayerSelector"
+            v-model="layerIndex"
+            :layers="layers"
+          />
         </l-control>
 
         <l-tile-layer
@@ -403,16 +407,19 @@ export default {
       currentEditableObject: null,
       layers: [
         {
+          title: 'reliefMapbox',
           name: 'Mapbox Outdoor',
           url: `https://api.mapbox.com/styles/v1/${process.env.VUE_APP_MAPBOX_TERRAIN_STYLE}/tiles/256/{z}/{x}/{y}@2x?access_token=${process.env.VUE_APP_MAPBOX_TOKEN}`,
           attribution: '&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'
         },
         {
+          title: 'satellite',
           name: 'Eseri Satelite',
           url: `https://api.mapbox.com/styles/v1/${process.env.VUE_APP_MAPBOX_SATELLITE_STYLE}/tiles/256/{z}/{x}/{y}@2x?access_token=${process.env.VUE_APP_MAPBOX_TOKEN}`,
           attribution: '&copy; <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'
         },
         {
+          title: 'detailedRelief',
           name: 'CyclOSM',
           url: 'https://{s}.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
           attribution: '&copy; <a href="https://www.cyclosm.org">CyclOSM</a> &copy; <a href="https://www.openstreetmap.org/about/">Open Street Map</a> contributors'


### PR DESCRIPTION
En lien avec #53 
ApproachForm et CragMapEditForm utilisaient les deux LeafletLayerSelector, mais ne lui transmettait pas de layers. Cela résultait en une liste vide au moment de choisir le fond de carte. Cet proposition règle ce bug en passant les mêmes arguments à LeafletLayerSelector que MapInput et LeafletMap. De plus, il a fallut éditer les deux listes de layers pour ajouter la propriété title, nécessaire à la localisation en français et en anglais. 