### PR TITLE
fix(typo): small typo in the private profile option description

### DIFF
--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -1698,8 +1698,8 @@ export default {
       },
       private_explain: {
         profile: 'Votre profil est consultable <strong>uniquement par les grimpeur·euse·s connecté·e·s</strong> à Oblyk.<br>Vous devez <strong>accepter manuellement</strong> les grimpeur·euse·s qui veulent vous suivre.',
-        outdoor_ascents: 'Votre carnet de croix outdoor est <strong>consultable uniquement pas vos abonné·es.</strong>',
-        indoor_ascents: 'Votre carnet de croix indoor est <strong>consultable uniquement pas vos abonné·es.</strong>'
+        outdoor_ascents: 'Votre carnet de croix outdoor est <strong>consultable uniquement par vos abonné·es.</strong>',
+        indoor_ascents: 'Votre carnet de croix indoor est <strong>consultable uniquement par vos abonné·es.</strong>'
       },
       contribution: {
         crags: 'Sites',


### PR DESCRIPTION
Fix lié à l'issue #92 

> Il y a une typo dans le processus d'inscription, lors de la description des options liées au profil privé. Il est écrit :
> uniquement pas vos abonné·es
> Au lieu de :
> uniquement par vos abonné·es
