### PR TITLE
Repetition fix

### DIFF
--- a/components/ascentCragRoutes/EditCragAscentBtn.vue
+++ b/components/ascentCragRoutes/EditCragAscentBtn.vue
@@ -26,7 +26,7 @@
           :ascent-crag-route="ascentCragRoute"
           submit-methode="put"
           :callback="successCallback"
-          :repetition=true
+          :repetition="true"
         />
       </v-card-text>
     </v-card>

--- a/components/ascentCragRoutes/EditCragAscentBtn.vue
+++ b/components/ascentCragRoutes/EditCragAscentBtn.vue
@@ -26,6 +26,7 @@
           :ascent-crag-route="ascentCragRoute"
           submit-methode="put"
           :callback="successCallback"
+          :repetition=true
         />
       </v-card-text>
     </v-card>

--- a/components/cragRoutes/CragRouteAscent.vue
+++ b/components/cragRoutes/CragRouteAscent.vue
@@ -88,7 +88,7 @@ export default {
         .catch((err) => {
           this.$root.$emit('alertFromApiError', err, 'ascentCragRouteApi')
         })
-        .then(() => {
+        .finally(() => {
           this.loadingAscents = false
         })
     }

--- a/pages/ascents/outdoor/new.vue
+++ b/pages/ascents/outdoor/new.vue
@@ -185,6 +185,7 @@
             submit-methode="post"
             :crag-route="cragRoute"
             :callback="ascentAdded"
+            :repetition=true
           />
         </v-sheet>
 

--- a/pages/ascents/outdoor/new.vue
+++ b/pages/ascents/outdoor/new.vue
@@ -181,7 +181,7 @@
             {{ $t('components.ascentCragRoute.new', { name: cragRoute.name } ) }}
           </p>
           <ascent-crag-route-form
-            v-if="cragRoute"
+            v-if="cragRoute && !loadingAscents"
             submit-methode="post"
             :crag-route="cragRoute"
             :callback="ascentAdded"
@@ -301,6 +301,7 @@ export default {
       loadingGrade: false,
       successAdded: false,
       ascents: [],
+      loadingAscents: false,
 
       mdiTerrain,
       mdiPlus,
@@ -335,6 +336,7 @@ export default {
     }
     if (cragRouteId) {
       this.getCragRoute(cragRouteId)
+      this.getAscents(cragRouteId)
     }
     this.$root.$on('searchCragRoutesResults', (results) => {
       this.haveCragRoutesResults(results)
@@ -398,7 +400,6 @@ export default {
         .finally(() => {
           this.loadingCragRoute = false
         })
-      this.getAscents(cragRouteId)
     },
 
     getAscents (cragRouteId) {
@@ -426,6 +427,7 @@ export default {
 
     selectCragRoute (cragRoute) {
       this.getCragRoute(cragRoute.id)
+      this.getAscents(cragRoute.id)
       this.addCragRouteBtn = false
     },
 

--- a/pages/ascents/outdoor/new.vue
+++ b/pages/ascents/outdoor/new.vue
@@ -185,7 +185,7 @@
             submit-methode="post"
             :crag-route="cragRoute"
             :callback="ascentAdded"
-            :repetition=true
+            :repetition="ascents.length > 0"
           />
         </v-sheet>
 
@@ -272,6 +272,8 @@ import AscentCragRouteForm from '~/components/ascentCragRoutes/forms/AscentCragR
 import CragRoutes from '~/components/cragRoutes/CragRoutes'
 import MyFollowedCrags from '~/components/users/MyFollowedCrags'
 import CragRouteDrawer from '~/components/cragRoutes/CragRouteDrawer'
+import AscentCragRouteApi from '~/services/oblyk-api/AscentCragRouteApi'
+import AscentCragRoute from '~/models/AscentCragRoute'
 
 export default {
   meta: { orphanRoute: true },
@@ -298,6 +300,7 @@ export default {
       grade: null,
       loadingGrade: false,
       successAdded: false,
+      ascents: [],
 
       mdiTerrain,
       mdiPlus,
@@ -394,6 +397,25 @@ export default {
         })
         .finally(() => {
           this.loadingCragRoute = false
+        })
+      this.getAscents(cragRouteId)
+    },
+
+    getAscents (cragRouteId) {
+      this.loadingAscents = true
+      this.ascents = []
+      new AscentCragRouteApi(this.$axios, this.$auth)
+        .all(cragRouteId)
+        .then((resp) => {
+          for (const ascent of resp.data) {
+            this.ascents.push(new AscentCragRoute({ attributes: ascent }))
+          }
+        })
+        .catch((err) => {
+          this.$root.$emit('alertFromApiError', err, 'ascentCragRouteApi')
+        })
+        .finally(() => {
+          this.loadingAscents = false
         })
     },
 


### PR DESCRIPTION
Ajoute le champ repetition dans acent_status_input dans les deux cas suivants :
1 - lors de l'ajout d'une ascent depuis le carnet outdoor (/ascents/outdoor/new) : seulement si il y a déjà une ascent (comme cela est déjà le cas quand on ajoute une ascent depuis une crag route page : button AddCragAscentBtn de la CragRouteAscent view)
2 - lors de l'edition d'une ascent déja existante