### PR TITLE
refactor: fix compilation warnings

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -204,7 +204,10 @@ export default {
     lazy: {
       skipNuxtState: true
     },
-    langDir: 'lang/'
+    langDir: 'lang/',
+    vueI18n: {
+      silentFallbackWarn: true
+    }
   },
 
   localforage: {

--- a/store/contestToken.js
+++ b/store/contestToken.js
@@ -1,7 +1,7 @@
 // States
-export const state = {
+export const state = () => ({
   contestTokens: {}
-}
+})
 
 // Getters
 export const getters = {

--- a/store/geolocation.js
+++ b/store/geolocation.js
@@ -1,9 +1,9 @@
 // States
-export const state = {
+export const state = () => ({
   latitude: null,
   longitude: null,
   status: null
-}
+})
 
 // Getters
 export const getters = {

--- a/store/likes.js
+++ b/store/likes.js
@@ -1,7 +1,7 @@
 // States
-export const state = {
+export const state = () => ({
   likes: {}
-}
+})
 
 // Getters
 export const getters = {

--- a/store/local.js
+++ b/store/local.js
@@ -1,7 +1,7 @@
 // States
-export const state = {
+export const state = () => ({
   lang: 'fr'
-}
+})
 
 // Getters
 export const getters = {

--- a/store/notification.js
+++ b/store/notification.js
@@ -1,7 +1,7 @@
 // States
-export const state = {
+export const state = () => ({
   newNotification: false
-}
+})
 
 // Getters
 export const getters = {

--- a/store/theme.js
+++ b/store/theme.js
@@ -1,7 +1,7 @@
 // States
-export const state = {
+export const state = () => ({
   theme: 'light'
-}
+})
 
 // Getters
 export const getters = {


### PR DESCRIPTION
Le warning lié aux traductions apparaît lorsqu'un composant déclare de la traduction locale, mais utilise aussi de la traduction globale.

Le warning sur le state indique que les stores doivent exporter une fonction