### PR TITLE
Refonte du redimensionement des images sur les groupes de salles

### DIFF
--- a/components/gymChains/layouts/GymChainHead.vue
+++ b/components/gymChains/layouts/GymChainHead.vue
@@ -3,9 +3,13 @@
     <v-img
       dark
       height="400px"
-      :lazy-src="gymChain.thumbnailBannerUrl"
-      :src="gymChain.croppedBannerUrl"
-      :srcset="`${gymChain.croppedBannerUrl} 500w, ${gymChain.bannerUrl} 600w`"
+      :lazy-src="imageVariant(gymChain.attachments.banner, { fit: 'scale-down', width: 640, height: 640 })"
+      :src="imageVariant(gymChain.attachments.banner, { fit: 'scale-down', width: 640, height: 640 })"
+      :srcset="`
+        ${imageVariant(gymChain.attachments.banner, { fit: 'scale-down', width: 640, height: 640 })} 640w,
+        ${imageVariant(gymChain.attachments.banner, { fit: 'scale-down', width: 960, height: 960 })} 960w,
+        ${imageVariant(gymChain.attachments.banner, { fit: 'scale-down', width: 1200, height: 1200 })} 1200w`
+      "
       class="gym-chain-header-banner"
     >
       <template #placeholder>
@@ -24,7 +28,7 @@
             class="mr-3 align-self-center rounded-sm"
           >
             <v-img
-              :src="gymChain.thumbnailLogoUrl"
+              :src="imageVariant(gymChain.attachments.logo, { fit: 'crop', width: 80, height: 80 })"
               :alt="`logo ${gymChain.name}`"
             />
           </v-avatar>
@@ -50,10 +54,12 @@
 
 <script>
 import ShareBtn from '~/components/ui/ShareBtn'
+import { ImageVariantHelpers } from '~/mixins/ImageVariantHelpers'
 
 export default {
   name: 'GymChainHead',
   components: { ShareBtn },
+  mixins: [ImageVariantHelpers],
   props: {
     gymChain: {
       type: Object,

--- a/components/gyms/GymContact.vue
+++ b/components/gyms/GymContact.vue
@@ -139,10 +139,10 @@
           :to="gymChain.path"
         >
           <v-avatar
-            v-if="gymChain.logo"
+            v-if="gymChain.attachments.logo.attached"
             left
           >
-            <v-img :src="gymChain.thumbnailLogoUrl" />
+            <v-img :src="imageVariant(gymChain.attachments.logo, { fit: 'scale-down', width: 40, height: 40, quality: 100 })" />
           </v-avatar>
           {{ gymChain.name }}
         </v-chip>
@@ -214,10 +214,11 @@ import {
 } from '@mdi/js'
 import { GymRolesHelpers } from '~/mixins/GymRolesHelpers'
 import GymChain from '~/models/GymChain'
+import { ImageVariantHelpers } from '~/mixins/ImageVariantHelpers'
 
 export default {
   name: 'GymContact',
-  mixins: [GymRolesHelpers],
+  mixins: [GymRolesHelpers, ImageVariantHelpers],
   props: {
     gym: {
       type: Object,

--- a/mixins/ImageVariantHelpers.js
+++ b/mixins/ImageVariantHelpers.js
@@ -1,0 +1,27 @@
+export const ImageVariantHelpers = {
+  methods: {
+    /**
+     * @desc Create the path to an image variant for given options
+     * @param {object} attachment
+     * @param {{fit: string, width: number, height: number, quality: number}} options
+     * @return string
+     */
+    imageVariant (attachment, options) {
+      // if we don't have an attachment, we'll replace it with a default image, depending on the type of attachement
+      if (attachment.attached === false) {
+        const defaultImage = {
+          GymChain_banner: '/images/gym-default-banner.jpg',
+          GymChain_logo: '/svg/gym-default-logo.svg'
+        }
+        return defaultImage[attachment.attachment_type]
+      }
+
+      // create path for image variant with variant options
+      const variants = ['onerror=redirect']
+      for (const option in options) {
+        variants.push([option, options[option]].join('='))
+      }
+      return attachment.variant_path.replace(':variant', variants.join(','))
+    }
+  }
+}

--- a/models/GymChain.js
+++ b/models/GymChain.js
@@ -21,44 +21,4 @@ export default class GymChain extends ActiveData {
   get adminPath () {
     return `/gym-chains/${this.slug_name}/admins`
   }
-
-  get bannerUrl () {
-    if (this.banner) {
-      return this.banner
-    } else {
-      return '/images/gym-default-banner.jpg'
-    }
-  }
-
-  get croppedBannerUrl () {
-    if (this.banner_cropped_url) {
-      return this.banner_cropped_url
-    } else {
-      return '/images/gym-default-banner.jpg'
-    }
-  }
-
-  get thumbnailBannerUrl () {
-    if (this.banner_thumbnail_url) {
-      return this.banner_thumbnail_url
-    } else {
-      return '/images/gym-default-banner.jpg'
-    }
-  }
-
-  get logoUrl () {
-    if (this.logo) {
-      return this.logo
-    } else {
-      return '/svg/gym-default-logo.svg'
-    }
-  }
-
-  get thumbnailLogoUrl () {
-    if (this.logo) {
-      return this.logo_thumbnail_url
-    } else {
-      return '/svg/gym-default-logo.svg'
-    }
-  }
 }


### PR DESCRIPTION
Le redimensionnements des images à un coût non négligeable côté serveur, surtout à l'ajout de voie indoor où un certain nombre de variante sont faite en peu de temps

Le module qui permet de checker l'existence d'une variante, de la créer et de l'envoyé sur R2 représente en moyen 17% du temps serveur. C'est le premier poste de dépense, de 10% supérieur au second poste.

On test de passer par Image Transform via URL de cloudflare sur les pages 'groupe de salle' pour tester le développement sur des pages peu demandées et peu impactantes

Pour ça on ajoute un mixine qui permet de choisir à la volet la variante d'une image, ça permettrai aussi de mieux gérer les variantes par rapport au cas d'usage

PR back : https://github.com/oblyk/oblyk-api/pull/18
