### PR TITLE
fix: error when displaying someone's ascents during a given month (from the leaderboard)

### DIFF
--- a/components/ascentGymRoutes/AscentGymRoutePoints.vue
+++ b/components/ascentGymRoutes/AscentGymRoutePoints.vue
@@ -84,11 +84,12 @@ import AscentGymRoute from '~/models/AscentGymRoute'
 import GymRouteTagAndHold from '~/components/gymRoutes/partial/GymRouteTagAndHold.vue'
 import AscentGymRouteIcon from '~/components/ascentGymRoutes/AscentGymRouteIcon.vue'
 import LoadingMore from '~/components/layouts/LoadingMore.vue'
+import { DateHelpers } from '~/mixins/DateHelpers'
 
 export default {
   name: 'AscentGymRoutePoints',
   components: { LoadingMore, AscentGymRouteIcon, GymRouteTagAndHold },
-  mixins: [LoadingMoreHelpers, ImageVariantHelpers],
+  mixins: [LoadingMoreHelpers, ImageVariantHelpers, DateHelpers],
   props: {
     climbingType: {
       type: String,
@@ -145,8 +146,8 @@ export default {
       }
 
       if (this.date !== 'opened') {
-        params.start_date = this.toDateTime(this.date).startOf('month')
-        params.end_date = this.toDateTime(this.date).endOf('month')
+        params.start_date = this.toDateTime(this.date).startOf('month').toISODate()
+        params.end_date = this.toDateTime(this.date).endOf('month').toISODate()
       }
 
       new AscentGymRouteApi(this.$axios, this.$auth)


### PR DESCRIPTION
Associée à https://github.com/oblyk/oblyk-api/pull/21

Permet d'afficher la liste des ascensions de quelqu'un, avec un filtre de mois sélectionné (sinon ça buggue)