### PR TITLE
Mise en place d'un système de sous niveau sur les blocs et voies indoor

### DIFF
--- a/components/forms/GymRouteSubLevelInput.vue
+++ b/components/forms/GymRouteSubLevelInput.vue
@@ -1,0 +1,78 @@
+<template>
+  <v-slider
+    v-if="gymLevels && gymLevels[climbingType] && gymLevels[climbingType].sub_level_enabled"
+    v-model="subLevel"
+    :label="$t('models.gymRoute.intensity')"
+    :tick-labels="tickLabels()"
+    track-color="rgba(150,150,150,0.4)"
+    :color="color"
+    min="0"
+    :prepend-icon="mdiChiliMild"
+    class="mb-5"
+    :max="gymLevels[climbingType].sub_level_max"
+    @change="onChange()"
+  />
+</template>
+
+<script>
+import { mdiChiliMild } from '@mdi/js'
+
+export default {
+  name: 'GymRouteSubLevelInput',
+  props: {
+    value: {
+      type: [Number, String],
+      default: null
+    },
+    gymLevels: {
+      type: Object,
+      required: true
+    },
+    climbingType: {
+      type: String,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      subLevel: this.value,
+
+      colors: {
+        0: [],
+        1: ['#a10026'],
+        2: ['#8bbc22', '#a10026'],
+        3: ['#8bbc22', '#f2b600', '#a10026'],
+        4: ['#8bbc22', '#f2b600', '#fd2605', '#a10026'],
+        5: ['#8bbc22', '#f2b600', '#f96a02', '#f11d10', '#a10026']
+      },
+
+      mdiChiliMild
+    }
+  },
+
+  computed: {
+    color () {
+      return this.colors[this.gymLevels[this.climbingType].sub_level_max][this.subLevel - 1]
+    }
+  },
+
+  methods: {
+    onChange () {
+      this.$emit('input', this.subLevel)
+    },
+
+    tickLabels () {
+      const labels = []
+      for (let i = 0; i <= this.gymLevels[this.climbingType].sub_level_max; i++) {
+        if (i === 0) {
+          labels.push('Ø')
+        } else {
+          labels.push(i)
+        }
+      }
+      return labels
+    }
+  }
+}
+</script>

--- a/components/gymRoutes/GymRouteInfo.vue
+++ b/components/gymRoutes/GymRouteInfo.vue
@@ -233,6 +233,23 @@
                 class="rounded-sm py-1"
               />
             </v-col>
+
+            <!-- Route sub level -->
+            <v-col
+              v-if="route.sub_level > 0"
+              cols="6"
+              class="my-1"
+            >
+              <description-line
+                :icon="mdiChiliMild"
+                :item-title="$t('models.gymRoute.intensity')"
+                class="rounded-sm py-1"
+              >
+                <template #content>
+                  <gym-route-sub-level-scale :gym-route="gymRoute" />
+                </template>
+              </description-line>
+            </v-col>
           </v-row>
 
           <!-- Difficulty appreciation -->
@@ -367,6 +384,7 @@ import {
   mdiCalendar,
   mdiTextureBox,
   mdiBolt,
+  mdiChiliMild,
   mdiPound,
   mdiMap,
   mdiGauge,
@@ -389,6 +407,7 @@ import GymCreateYourAccount from '~/components/gyms/GymCreateYourAccount'
 import GymRouteApi from '~/services/oblyk-api/GymRouteApi'
 import GymRoute from '~/models/GymRoute'
 import GymRouteTagAndHoldV2 from '~/components/gymRoutes/partial/GymRouteTagAndHoldV2'
+import GymRouteSubLevelScale from '~/components/gymRoutes/GymRouteSubLevelScale'
 
 const GymRouteVideoList = () => import('@/components/gymRoutes/GymRouteVideoList')
 const CommentList = () => import('@/components/comments/CommentList')
@@ -397,6 +416,7 @@ const MarkdownText = () => import('@/components/ui/MarkdownText')
 export default {
   name: 'GymRouteInfo',
   components: {
+    GymRouteSubLevelScale,
     GymRouteTagAndHoldV2,
     GymCreateYourAccount,
     GymRouteVideoList,
@@ -454,7 +474,8 @@ export default {
       mdiGauge,
       mdiArrowRight,
       mdiShield,
-      mdiInformation
+      mdiInformation,
+      mdiChiliMild
     }
   },
 

--- a/components/gymRoutes/GymRouteListItem.vue
+++ b/components/gymRoutes/GymRouteListItem.vue
@@ -71,8 +71,16 @@
         <div class="mr-auto text-truncate">
           {{ gymRoute.name }}
         </div>
-        <div class="pt-1">
-          <gym-route-grade-and-point :gym-route="gymRoute" />
+        <div class="pt-1 text-no-wrap">
+          <gym-route-grade-and-point
+            :gym-route="gymRoute"
+            inline
+          />
+          <gym-route-sub-level
+            v-if="gymRoute.sub_level"
+            class="ml-1"
+            :gym-route="gymRoute"
+          />
         </div>
       </v-list-item-title>
       <v-list-item-subtitle class="d-flex">
@@ -149,10 +157,12 @@ import { MyAscentStatusMixin } from '~/mixins/MyAscentStatusMixin'
 import GymRouteGradeAndPoint from '~/components/gymRoutes/partial/GymRouteGradeAndPoint'
 import GymRouteAvatar from '~/components/gymRoutes/GymRouteAvatar'
 import GymRouteClimbingSimpleStyleIcons from '~/components/gymRoutes/partial/GymRouteClimbingSimpleStyleIcons'
+import GymRouteSubLevel from '~/components/gymRoutes/GymRouteSubLevel.vue'
 
 export default {
   name: 'GymRouteListItem',
   components: {
+    GymRouteSubLevel,
     GymRouteClimbingSimpleStyleIcons,
     GymRouteAvatar,
     GymRouteGradeAndPoint

--- a/components/gymRoutes/GymRouteSubLevel.vue
+++ b/components/gymRoutes/GymRouteSubLevel.vue
@@ -1,0 +1,53 @@
+<template>
+  <span
+    :style="`color: ${color};`"
+    class="font-weight-bold"
+  >
+    <span>
+      {{ gymRoute.sub_level }}
+    </span>
+    <v-icon
+      class="vertical-align-text-top"
+      :color="color"
+      small
+      style="margin-left: -6px; padding-top: 1px"
+    >
+      {{ mdiChiliMild }}
+    </v-icon>
+  </span>
+</template>
+
+<script>
+import { mdiChiliMild } from '@mdi/js'
+
+export default {
+  name: 'GymRouteSubLevel',
+  props: {
+    gymRoute: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      colors: {
+        0: [],
+        1: ['#a10026'],
+        2: ['#8bbc22', '#a10026'],
+        3: ['#8bbc22', '#f2b600', '#a10026'],
+        4: ['#8bbc22', '#f2b600', '#fd2605', '#a10026'],
+        5: ['#8bbc22', '#f2b600', '#f96a02', '#f11d10', '#a10026']
+      },
+
+      mdiChiliMild
+    }
+  },
+
+  computed: {
+    color () {
+      return this.colors[this.gymRoute.sub_level_max][this.gymRoute.sub_level - 1]
+    }
+  }
+}
+</script>

--- a/components/gymRoutes/GymRouteSubLevelScale.vue
+++ b/components/gymRoutes/GymRouteSubLevelScale.vue
@@ -1,0 +1,42 @@
+<template>
+  <span>
+    <v-icon
+      v-for="(level, levelIndex) in gymRoute.sub_level_max"
+      :key="`level-${levelIndex}`"
+      :color="gymRoute.sub_level >= level ? colors[gymRoute.sub_level_max][gymRoute.sub_level - 1] : 'rgba(150, 150, 150, 0.3)'"
+      size="17"
+      style="margin-right: -6px;"
+    >
+      {{ mdiChiliMild }}
+    </v-icon>
+  </span>
+</template>
+
+<script>
+import { mdiChiliMild } from '@mdi/js'
+
+export default {
+  name: 'GymRouteSubLevelScale',
+  props: {
+    gymRoute: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data () {
+    return {
+      colors: {
+        0: [],
+        1: ['#a10026'],
+        2: ['#8bbc22', '#a10026'],
+        3: ['#8bbc22', '#f2b600', '#a10026'],
+        4: ['#8bbc22', '#f2b600', '#fd2605', '#a10026'],
+        5: ['#8bbc22', '#f2b600', '#f96a02', '#f11d10', '#a10026']
+      },
+
+      mdiChiliMild
+    }
+  }
+}
+</script>

--- a/components/gymRoutes/GymRouteTable.vue
+++ b/components/gymRoutes/GymRouteTable.vue
@@ -140,6 +140,15 @@
             </template>
             <template
               v-once
+              #[`item.subLevel`]="{ item }"
+            >
+              <gym-route-sub-level-scale
+                v-if="item.subLevel"
+                :gym-route="{ sub_level: item.subLevel, sub_level_max: item.subLevelMax }"
+              />
+            </template>
+            <template
+              v-once
               #[`item.openedAt`]="{ item }"
             >
               <v-btn
@@ -435,6 +444,8 @@ import {
 } from '@mdi/js'
 import { DateHelpers } from '@/mixins/DateHelpers'
 import { GymRolesHelpers } from '~/mixins/GymRolesHelpers'
+import { ClimbingStylesMixin } from '~/mixins/ClimbingStylesMixin'
+import { ImageVariantHelpers } from '~/mixins/ImageVariantHelpers'
 import GymApi from '~/services/oblyk-api/GymApi'
 import GymRoute from '@/models/GymRoute'
 import GymRouteTagAndHold from '@/components/gymRoutes/partial/GymRouteTagAndHold'
@@ -446,13 +457,13 @@ import GymSpace from '~/models/GymSpace'
 import DownToCloseDialog from '~/components/ui/DownToCloseDialog'
 import GymRouteInfo from '~/components/gymRoutes/GymRouteInfo'
 import OpeningSheetDialog from '~/components/gymOpeningSheets/OpeningSheetDialog'
-import { ImageVariantHelpers } from '~/mixins/ImageVariantHelpers'
 import AscentGymRouteIcon from '~/components/ascentGymRoutes/AscentGymRouteIcon'
-import { ClimbingStylesMixin } from '~/mixins/ClimbingStylesMixin'
+import GymRouteSubLevelScale from '~/components/gymRoutes/GymRouteSubLevelScale'
 
 export default {
   name: 'GymRoutesTable',
   components: {
+    GymRouteSubLevelScale,
     AscentGymRouteIcon,
     OpeningSheetDialog,
     GymRouteInfo,
@@ -599,6 +610,7 @@ export default {
       let haveAnchor = false
       let haveName = false
       let haveGrade = false
+      let haveSubLevel = false
       for (const route of this.routes) {
         // Add anchor column
         if (!haveAnchor && route.anchor_number !== null) {
@@ -613,6 +625,21 @@ export default {
           })
           haveAnchor = true
         }
+
+        // Add subLevel column
+        if (!haveSubLevel && route.sub_level > 0) {
+          headers.push({
+            order: 4.1,
+            text: this.$t('models.gymRoute.intensity'),
+            align: 'start',
+            sortable: true,
+            cellClass: 'text-no-wrap',
+            class: 'text-no-wrap',
+            value: 'subLevel'
+          })
+          haveSubLevel = true
+        }
+
         // Add name column
         if (!haveName && route.name !== null) {
           headers.push({
@@ -625,6 +652,7 @@ export default {
           })
           haveName = true
         }
+
         // Add grade column
         if (!haveGrade && route.grade_to_s !== null) {
           headers.push({
@@ -754,6 +782,8 @@ export default {
             point_to_s: route.points_to_s,
             points: route.points,
             styles,
+            subLevel: route.sub_level,
+            subLevelMax: route.sub_level_max,
             anchorNumber: route.anchor_number,
             sector: route.gym_sector.name,
             gym_space: {

--- a/components/gymRoutes/forms/GymRouteForm.vue
+++ b/components/gymRoutes/forms/GymRouteForm.vue
@@ -14,6 +14,13 @@
         :change-callback="onChangeLevelPreset"
       />
 
+      <!-- Gym sub level -->
+      <gym-route-sub-level-input
+        v-model="data.sub_level"
+        :gym-levels="gymLevels"
+        :climbing-type="data.climbing_type"
+      />
+
       <!-- Route name -->
       <v-row :class="cragRoute.name ? 'mb-0' : 'mb-4'">
         <v-col
@@ -481,6 +488,7 @@ import {
 import { FormHelpers } from '@/mixins/FormHelpers'
 import { HoldColorsHelpers } from '@/mixins/HoldColorsHelpers'
 import { DateHelpers } from '@/mixins/DateHelpers'
+import { GradeMixin } from '~/mixins/GradeMixin'
 import Spinner from '@/components/layouts/Spiner'
 import GymRouteApi from '~/services/oblyk-api/GymRouteApi'
 import ColorInput from '@/components/forms/ColorInput'
@@ -489,19 +497,20 @@ import CragRouteApi from '~/services/oblyk-api/CragRouteApi'
 import CragRoute from '@/models/CragRoute'
 import MarkdownInput from '@/components/forms/MarkdownInput'
 import GymOpenerInput from '~/components/forms/GymOpenerInput'
-import DatePickerMenuInput from '~/components/forms/DatePickerMenuInput.vue'
-import IndoorClimbingStylesInput from '~/components/forms/IndoorClimbingStyleInput.vue'
-import GymRouteTagAndHold from '~/components/gymRoutes/partial/GymRouteTagAndHold.vue'
+import DatePickerMenuInput from '~/components/forms/DatePickerMenuInput'
+import IndoorClimbingStylesInput from '~/components/forms/IndoorClimbingStyleInput'
+import GymRouteTagAndHold from '~/components/gymRoutes/partial/GymRouteTagAndHold'
 import GymLevelApi from '~/services/oblyk-api/GymLevelApi'
 import GymLevel from '~/models/GymLevel'
-import GymRouteLevelInput from '~/components/forms/GymRouteLevelInput.vue'
-import { GradeMixin } from '~/mixins/GradeMixin'
-const GymRouteThumbnailForm = () => import('~/components/gymRoutes/forms/GymRouteThumbnailForm.vue')
-const GymRoutePictureForm = () => import('~/components/gymRoutes/forms/GymRoutePictureForm.vue')
+import GymRouteLevelInput from '~/components/forms/GymRouteLevelInput'
+import GymRouteSubLevelInput from '~/components/forms/GymRouteSubLevelInput'
+const GymRouteThumbnailForm = () => import('~/components/gymRoutes/forms/GymRouteThumbnailForm')
+const GymRoutePictureForm = () => import('~/components/gymRoutes/forms/GymRoutePictureForm')
 
 export default {
   name: 'GymRouteForm',
   components: {
+    GymRouteSubLevelInput,
     GymRouteLevelInput,
     GymRouteTagAndHold,
     IndoorClimbingStylesInput,
@@ -559,6 +568,7 @@ export default {
         opened_at: this.gymRoute?.opened_at || this.ISODateToday(),
         climbing_type: this.gymRoute?.climbing_type || this.gymSector.climbing_type || 'sport_climbing',
         anchor_number: this.gymRoute?.anchor_number,
+        sub_level: this.gymRoute?.sub_level,
         gym_space_id: this.gymSector.gym_space.id,
         gym_sector_id: null,
         gym_id: this.gymSector.gym.id,

--- a/components/gyms/forms/LevelsForm.vue
+++ b/components/gyms/forms/LevelsForm.vue
@@ -28,6 +28,22 @@
                 :gym-level="data.sport_climbing"
                 @input="changes = true"
               />
+              <v-checkbox
+                v-model="data.sport_climbing.sub_level_enabled"
+                label="Activer les sous niveaux pour la voie"
+                @input="changes = true"
+              />
+              <v-text-field
+                v-if="data.sport_climbing.sub_level_enabled"
+                v-model="data.sport_climbing.sub_level_max"
+                label="Nombre de sous niveau"
+                type="number"
+                outlined
+                persistent-hint
+                hint="Nous conseillons 3 ou 5 niveaux"
+                :rules="[rules.subLevel]"
+                @input="changes = true"
+              />
             </div>
             <p
               v-else
@@ -65,6 +81,22 @@
                 :gym-level="data.bouldering"
                 @input="changes = true"
               />
+              <v-checkbox
+                v-model="data.bouldering.sub_level_enabled"
+                label="Activer les sous niveaux pour le bloc"
+                @input="changes = true"
+              />
+              <v-text-field
+                v-if="data.bouldering.sub_level_enabled"
+                v-model="data.bouldering.sub_level_max"
+                label="Nombre de sous niveau"
+                type="number"
+                outlined
+                persistent-hint
+                :rules="[rules.subLevel]"
+                hint="Nous conseillons 3 ou 5 niveaux"
+                @input="changes = true"
+              />
             </div>
             <p
               v-else
@@ -100,6 +132,22 @@
                 v-model="data.pan.levels"
                 hide-details
                 :gym-level="data.pan"
+                @input="changes = true"
+              />
+              <v-checkbox
+                v-model="data.pan.sub_level_enabled"
+                label="Activer les sous niveaux pour le pan"
+                @input="changes = true"
+              />
+              <v-text-field
+                v-if="data.pan.sub_level_enabled"
+                v-model="data.bouldering.sub_level_max"
+                label="Nombre de sous niveau"
+                type="number"
+                outlined
+                persistent-hint
+                hint="Nous conseillons 3 ou 5 niveaux"
+                :rules="[rules.subLevel]"
                 @input="changes = true"
               />
             </div>
@@ -162,22 +210,32 @@ export default {
           enabled: this.gymLevels.sport_climbing.enabled,
           grade_system: this.gymLevels.sport_climbing.grade_system,
           level_representation: this.gymLevels.sport_climbing.level_representation,
-          levels: this.gymLevels.sport_climbing.levels
+          levels: this.gymLevels.sport_climbing.levels,
+          sub_level_enabled: this.gymLevels.sport_climbing.sub_level_enabled,
+          sub_level_max: this.gymLevels.sport_climbing.sub_level_max
         },
         bouldering: {
           climbing_type: 'bouldering',
           enabled: this.gymLevels.bouldering.enabled,
           grade_system: this.gymLevels.bouldering.grade_system,
           level_representation: this.gymLevels.bouldering.level_representation,
-          levels: this.gymLevels.bouldering.levels
+          levels: this.gymLevels.bouldering.levels,
+          sub_level_enabled: this.gymLevels.bouldering.sub_level_enabled,
+          sub_level_max: this.gymLevels.bouldering.sub_level_max
         },
         pan: {
           climbing_type: 'pan',
           enabled: this.gymLevels.pan.enabled,
           grade_system: this.gymLevels.pan.grade_system,
           level_representation: this.gymLevels.pan.level_representation,
-          levels: this.gymLevels.pan.levels
+          levels: this.gymLevels.pan.levels,
+          sub_level_enabled: this.gymLevels.pan.sub_level_enabled,
+          sub_level_max: this.gymLevels.pan.sub_level_max
         }
+      },
+
+      rules: {
+        subLevel: value => (value >= 1 && value <= 5) || 'Doit être compris entre 1 et 5'
       }
     }
   },

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -2604,7 +2604,10 @@ export default {
       styles: 'Styles',
       grade_by_section: 'Grade L.%{index}',
       anchor_number: 'Anchor n°',
-      fixedPoints: 'Give a fixed number of points'
+      fixedPoints: 'Give a fixed number of points',
+      intensity: 'Intensity',
+      difficulty: 'Difficulty',
+      sub_level: 'Sub level'
     },
     gymGrade: {
       name: 'System name',

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -2605,7 +2605,10 @@ export default {
       styles: 'Styles',
       grade_by_section: 'Cotation L.%{index}',
       anchor_number: 'Relais n°',
-      fixedPoints: 'Donner un nombre de points fixe'
+      fixedPoints: 'Donner un nombre de points fixe',
+      intensity: 'Intensité',
+      difficulty: 'Difficulté',
+      sub_level: 'Sous niveau'
     },
     gymGrade: {
       name: 'Nom du système',


### PR DESCRIPTION
Ajout d'un système de sous niveau qui se matérialise pas des piments sur l'interface

Les niveaux sont activable ou pas suivant la typologie de grimpe (bloc, voie ou pan)

On peut choisir de 1 à 5 niveaux

Exemple dans le topo :

<img width="805" height="1095" alt="image" src="https://github.com/user-attachments/assets/781a7f00-398f-4f54-92d4-326dcc94666f" />

Exemple dans le détail d'une voie

<img width="1074" height="469" alt="image" src="https://github.com/user-attachments/assets/29b60a7e-3638-4c43-8114-6c316218d48a" />

Exemple dans le tableau des voies

<img width="1554" height="459" alt="image" src="https://github.com/user-attachments/assets/e3b872d3-e539-4f4a-8c62-0e1e7bc351bf" />

Closes #174 

