### PR TITLE
feat: tirage d'une voie aléatoire par niveau min/max (site + salle)

### DIFF
--- a/components/cragRoutes/CragRoutes.vue
+++ b/components/cragRoutes/CragRoutes.vue
@@ -79,6 +79,16 @@
           <v-col v-if="showRouteSort">
             <crag-route-sort v-model="routeSort" />
           </v-col>
+          <v-col
+            cols="12"
+            md="4"
+            lg="3"
+          >
+            <crag-random-route
+              :crag="crag"
+              :crag-sector="cragSector"
+            />
+          </v-col>
           <v-col>
             <crag-sector-selector
               v-model="cragSectorId"
@@ -174,11 +184,13 @@ import AddSectorOrRouteBtn from '@/components/cragRoutes/partial/AddSectorOrRout
 import CragSectorSelector from '@/components/cragRoutes/partial/CragSectorSelector'
 import CragRouteSort from '@/components/cragRoutes/partial/CragRouteSort'
 import CragRouteSearch from '@/components/cragRoutes/partial/CragRouteSearch'
+import CragRandomRoute from '@/components/cragRoutes/partial/CragRandomRoute'
 import CragRouteFigures from '@/components/cragRoutes/CragRouteFigures'
 
 export default {
   name: 'CragRoutes',
   components: {
+    CragRandomRoute,
     CragRouteFigures,
     CragRouteSearch,
     CragRouteSort,

--- a/components/cragRoutes/partial/CragRandomRoute.vue
+++ b/components/cragRoutes/partial/CragRandomRoute.vue
@@ -1,0 +1,208 @@
+<template>
+  <div class="d-inline">
+    <v-btn
+      text
+      block
+      x-large
+      outlined
+      @click="dialog = true"
+    >
+      <v-icon left>
+        {{ mdiDiceMultiple }}
+      </v-icon>
+      {{ $t('components.cragRoute.randomRoute') }}
+    </v-btn>
+    <v-dialog
+      v-model="dialog"
+      max-width="500"
+    >
+      <v-card>
+        <v-card-title>
+          {{ $t('components.cragRoute.randomRouteTitle') }}
+        </v-card-title>
+        <v-card-text>
+          <p class="text--secondary">
+            {{ $t('components.cragRoute.randomRouteExplain') }}
+          </p>
+          <v-row>
+            <v-col cols="6">
+              <grade-select-input
+                v-model="minGrade"
+                :translate-key="'components.cragRoute.minGrade'"
+              />
+            </v-col>
+            <v-col cols="6">
+              <grade-select-input
+                v-model="maxGrade"
+                :translate-key="'components.cragRoute.maxGrade'"
+              />
+            </v-col>
+          </v-row>
+          <v-alert
+            v-if="error"
+            dense
+            text
+            type="error"
+            class="mt-2"
+          >
+            {{ error }}
+          </v-alert>
+          <div v-if="randomRoute" class="mt-2">
+            <crag-route-list-item
+              :route="randomRoute"
+              :callback="openRandomRoute"
+              class="border rounded"
+            />
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            text
+            @click="dialog = false"
+          >
+            {{ $t('actions.close') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            :loading="loading"
+            :disabled="loading"
+            @click="pickRandom"
+          >
+            <v-icon left small>
+              {{ mdiDiceMultiple }}
+            </v-icon>
+            {{ randomRoute ? $t('components.cragRoute.pickAgain') : $t('components.cragRoute.pickRandom') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import { mdiDiceMultiple } from '@mdi/js'
+import CragRoute from '@/models/CragRoute'
+import OblykApi from '~/services/oblyk-api/OblykApi'
+import GradeSelectInput from '@/components/forms/GradeSelectInput'
+import CragRouteListItem from '@/components/cragRoutes/CragRouteListItem'
+
+const PER_PAGE = 25
+const MAX_PAGES = 40
+
+export default {
+  name: 'CragRandomRoute',
+  components: {
+    GradeSelectInput,
+    CragRouteListItem
+  },
+  props: {
+    crag: {
+      type: Object,
+      default: null
+    },
+    cragSector: {
+      type: Object,
+      default: null
+    }
+  },
+
+  data () {
+    return {
+      dialog: false,
+      minGrade: null,
+      maxGrade: null,
+      loading: false,
+      randomRoute: null,
+      error: null,
+
+      mdiDiceMultiple
+    }
+  },
+
+  methods: {
+    routeMinValue (route) {
+      return route.grade_gap?.min_grade_value ?? route.grade_gap?.max_grade_value ?? null
+    },
+
+    routeMaxValue (route) {
+      return route.grade_gap?.max_grade_value ?? route.grade_gap?.min_grade_value ?? null
+    },
+
+    routeInRange (route) {
+      const min = this.routeMinValue(route)
+      const max = this.routeMaxValue(route)
+      if (min === null || max === null) {
+        return false
+      }
+      if (this.minGrade !== null && this.minGrade !== '' && max < Number(this.minGrade)) {
+        return false
+      }
+      if (this.maxGrade !== null && this.maxGrade !== '' && min > Number(this.maxGrade)) {
+        return false
+      }
+      return true
+    },
+
+    routesUrl () {
+      if (this.cragSector) {
+        return `/public/crag_sectors/${this.cragSector.id}/crag_routes`
+      }
+      return `/public/crags/${this.crag.id}/crag_routes`
+    },
+
+    fetchAllRoutes () {
+      const api = new OblykApi(this.$axios, this.$auth)
+      const url = this.routesUrl()
+      const allRoutes = []
+      let page = 1
+
+      const fetchPage = () => {
+        return api.get(url, { page }).then((resp) => {
+          for (const attrs of resp.data) {
+            allRoutes.push(new CragRoute({ attributes: attrs }))
+          }
+          if (resp.data.length >= PER_PAGE && page < MAX_PAGES) {
+            page += 1
+            return fetchPage()
+          }
+          return allRoutes
+        })
+      }
+
+      return fetchPage()
+    },
+
+    pickRandom () {
+      this.error = null
+      if (this.minGrade !== null && this.minGrade !== '' && this.maxGrade !== null && this.maxGrade !== '' && Number(this.minGrade) > Number(this.maxGrade)) {
+        this.error = this.$t('components.cragRoute.minMaxError')
+        return
+      }
+      this.loading = true
+      this.randomRoute = null
+      this.fetchAllRoutes()
+        .then((routes) => {
+          const filtered = routes.filter(route => this.routeInRange(route))
+          if (filtered.length === 0) {
+            this.error = this.$t('components.cragRoute.noRouteInRange')
+            return
+          }
+          const index = Math.floor(Math.random() * filtered.length)
+          this.randomRoute = filtered[index]
+        })
+        .catch((err) => {
+          this.$root.$emit('alertFromApiError', err, 'cragRoute')
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    },
+
+    openRandomRoute (route) {
+      this.dialog = false
+      this.$root.$emit('getCragRouteInDrawer', route.crag.id, route.id)
+    }
+  }
+}
+</script>

--- a/components/gymRoutes/GymSpaceRouteList.vue
+++ b/components/gymRoutes/GymSpaceRouteList.vue
@@ -28,6 +28,12 @@
         :gym-space="gymSpace"
       />
 
+      <!-- RANDOM ROUTE BTN -->
+      <gym-random-route
+        :gym="gym"
+        :gym-space="gymSpace"
+      />
+
       <!-- FILTER BTN -->
       <gym-routes-filter-btn
         :gym="gym"
@@ -217,11 +223,13 @@ import OpenedAtSeparator from '~/components/gymRoutes/listByGroup/OpenedAtSepara
 import AscentGymMultiCheckDialog from '~/components/ascentGymRoutes/AscentGymMultiCheckDialog'
 import AscentGymMultiCheckSuccessModal from '~/components/ascentGymRoutes/AscentGymMultiCheckSuccessModal'
 import GymRoutesFilterBtn from '~/components/gymRoutes/partial/GymRoutesFilterBtn'
+import GymRandomRoute from '~/components/gymRoutes/partial/GymRandomRoute'
 import OblykApi from '~/services/oblyk-api/OblykApi'
 
 export default {
   name: 'GymSpaceRouteList',
   components: {
+    GymRandomRoute,
     GymRoutesFilterBtn,
     AscentGymMultiCheckSuccessModal,
     AscentGymMultiCheckDialog,

--- a/components/gymRoutes/partial/GymRandomRoute.vue
+++ b/components/gymRoutes/partial/GymRandomRoute.vue
@@ -127,12 +127,32 @@ export default {
   },
 
   methods: {
+    routeGradeValues (route) {
+      const values = []
+      if (route.grade_gap && (route.grade_gap.min_grade_value || route.grade_gap.max_grade_value)) {
+        if (route.grade_gap.min_grade_value) {
+          values.push(Number(route.grade_gap.min_grade_value))
+        }
+        if (route.grade_gap.max_grade_value) {
+          values.push(Number(route.grade_gap.max_grade_value))
+        }
+      }
+      for (const section of route.sections || []) {
+        if (section.grade_value !== null && section.grade_value !== undefined) {
+          values.push(Number(section.grade_value))
+        }
+      }
+      return values
+    },
+
     routeMinValue (route) {
-      return route.grade_gap?.min_grade_value ?? route.grade_gap?.max_grade_value ?? null
+      const values = this.routeGradeValues(route)
+      return values.length > 0 ? Math.min(...values) : null
     },
 
     routeMaxValue (route) {
-      return route.grade_gap?.max_grade_value ?? route.grade_gap?.min_grade_value ?? null
+      const values = this.routeGradeValues(route)
+      return values.length > 0 ? Math.max(...values) : null
     },
 
     routeInRange (route) {

--- a/components/gymRoutes/partial/GymRandomRoute.vue
+++ b/components/gymRoutes/partial/GymRandomRoute.vue
@@ -1,0 +1,229 @@
+<template>
+  <div class="d-inline">
+    <v-tooltip bottom>
+      <template #activator="{ on, attrs }">
+        <v-btn
+          icon
+          v-bind="attrs"
+          :title="$t('components.gymRoute.randomRoute')"
+          v-on="on"
+          @click="dialog = true"
+        >
+          <v-icon>
+            {{ mdiDiceMultiple }}
+          </v-icon>
+        </v-btn>
+      </template>
+      <span>
+        {{ $t('components.gymRoute.randomRoute') }}
+      </span>
+    </v-tooltip>
+    <v-dialog
+      v-model="dialog"
+      max-width="500"
+    >
+      <v-card>
+        <v-card-title>
+          {{ $t('components.gymRoute.randomRouteTitle') }}
+        </v-card-title>
+        <v-card-text>
+          <p class="text--secondary">
+            {{ $t('components.gymRoute.randomRouteExplain') }}
+          </p>
+          <v-row>
+            <v-col cols="6">
+              <grade-select-input
+                v-model="minGrade"
+                :translate-key="'components.gymRoute.minGrade'"
+              />
+            </v-col>
+            <v-col cols="6">
+              <grade-select-input
+                v-model="maxGrade"
+                :translate-key="'components.gymRoute.maxGrade'"
+              />
+            </v-col>
+          </v-row>
+          <v-alert
+            v-if="error"
+            dense
+            text
+            type="error"
+            class="mt-2"
+          >
+            {{ error }}
+          </v-alert>
+          <div v-if="randomRoute" class="mt-2">
+            <gym-route-list-item
+              :gym-route="randomRoute"
+              :click-callback="openRandomRoute"
+              bordered
+            />
+          </div>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            text
+            @click="dialog = false"
+          >
+            {{ $t('actions.close') }}
+          </v-btn>
+          <v-btn
+            color="primary"
+            :loading="loading"
+            :disabled="loading"
+            @click="pickRandom"
+          >
+            <v-icon left small>
+              {{ mdiDiceMultiple }}
+            </v-icon>
+            {{ randomRoute ? $t('components.gymRoute.pickAgain') : $t('components.gymRoute.pickRandom') }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+import { mdiDiceMultiple } from '@mdi/js'
+import GymRouteApi from '~/services/oblyk-api/GymRouteApi'
+import GymRoute from '@/models/GymRoute'
+import GradeSelectInput from '@/components/forms/GradeSelectInput'
+import GymRouteListItem from '~/components/gymRoutes/GymRouteListItem'
+
+const PER_PAGE = 25
+const MAX_PAGES = 40
+
+export default {
+  name: 'GymRandomRoute',
+  components: {
+    GradeSelectInput,
+    GymRouteListItem
+  },
+  props: {
+    gym: {
+      type: Object,
+      required: true
+    },
+    gymSpace: {
+      type: Object,
+      default: null
+    }
+  },
+
+  data () {
+    return {
+      dialog: false,
+      minGrade: null,
+      maxGrade: null,
+      loading: false,
+      randomRoute: null,
+      error: null,
+
+      mdiDiceMultiple
+    }
+  },
+
+  methods: {
+    routeMinValue (route) {
+      return route.grade_gap?.min_grade_value ?? route.grade_gap?.max_grade_value ?? null
+    },
+
+    routeMaxValue (route) {
+      return route.grade_gap?.max_grade_value ?? route.grade_gap?.min_grade_value ?? null
+    },
+
+    routeInRange (route) {
+      const min = this.routeMinValue(route)
+      const max = this.routeMaxValue(route)
+      if (min === null || max === null) {
+        return false
+      }
+      if (this.minGrade !== null && this.minGrade !== '' && max < Number(this.minGrade)) {
+        return false
+      }
+      if (this.maxGrade !== null && this.maxGrade !== '' && min > Number(this.maxGrade)) {
+        return false
+      }
+      return true
+    },
+
+    fetchPage (api, page) {
+      if (this.gymSpace) {
+        return api.paginatedRoutesInSpace(
+          this.gymSpace.gym.id,
+          this.gymSpace.id,
+          'sector',
+          'asc',
+          page,
+          false,
+          null
+        )
+      }
+      return api.paginatedRoutesInGym(
+        this.gym.id,
+        'sector',
+        'asc',
+        page,
+        false,
+        null
+      )
+    },
+
+    fetchAllRoutes () {
+      const api = new GymRouteApi(this.$axios, this.$auth)
+      const allRoutes = []
+      let page = 1
+
+      const fetchNext = () => {
+        return this.fetchPage(api, page).then((resp) => {
+          for (const attrs of resp.data) {
+            allRoutes.push(new GymRoute({ attributes: attrs }))
+          }
+          if (resp.data.length >= PER_PAGE && page < MAX_PAGES) {
+            page += 1
+            return fetchNext()
+          }
+          return allRoutes
+        })
+      }
+
+      return fetchNext()
+    },
+
+    pickRandom () {
+      this.error = null
+      if (this.minGrade !== null && this.minGrade !== '' && this.maxGrade !== null && this.maxGrade !== '' && Number(this.minGrade) > Number(this.maxGrade)) {
+        this.error = this.$t('components.gymRoute.minMaxError')
+        return
+      }
+      this.loading = true
+      this.randomRoute = null
+      this.fetchAllRoutes()
+        .then((routes) => {
+          const filtered = routes.filter(route => this.routeInRange(route))
+          if (filtered.length === 0) {
+            this.error = this.$t('components.gymRoute.noRouteInRange')
+            return
+          }
+          const index = Math.floor(Math.random() * filtered.length)
+          this.randomRoute = filtered[index]
+        })
+        .catch((err) => {
+          this.$root.$emit('alertFromApiError', err, 'gymRoute')
+        })
+        .finally(() => {
+          this.loading = false
+        })
+    },
+
+    openRandomRoute (route) {
+      this.dialog = false
+      const query = { ...this.$route.query, route: route.id }
+      this.$router.push({ path: this.$route.path, query })
+    }
+  }
+}
+</script>

--- a/lang/en-US.js
+++ b/lang/en-US.js
@@ -1105,7 +1105,16 @@ export default {
         difficulty_asc: 'From the easiest to the hardest',
         name: 'By name',
         note: 'By note'
-      }
+      },
+      randomRoute: 'Random route',
+      randomRouteTitle: 'Pick a random route',
+      randomRouteExplain: 'Choose a grade range, we will suggest a random route on this crag.',
+      minGrade: 'Min grade',
+      maxGrade: 'Max grade',
+      pickRandom: 'Pick randomly',
+      pickAgain: 'Pick again',
+      noRouteInRange: 'No route found in this grade range.',
+      minMaxError: 'Min grade must be lower than or equal to max grade.'
     },
     cragsTable: {
       crags: 'Crags',
@@ -1607,7 +1616,16 @@ export default {
         ascents_count: 'Sort by number of ascents',
         likes_count: 'Sort by number of likes',
         comments_count: 'Sort by number of comments'
-      }
+      },
+      randomRoute: 'Random line',
+      randomRouteTitle: 'Pick a random line',
+      randomRouteExplain: 'Choose a grade range, we will suggest a random line in this space.',
+      minGrade: 'Min grade',
+      maxGrade: 'Max grade',
+      pickRandom: 'Pick randomly',
+      pickAgain: 'Pick again',
+      noRouteInRange: 'No line found in this grade range.',
+      minMaxError: 'Min grade must be lower than or equal to max grade.'
     },
     contest: {
       title: 'Contests',

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -1106,7 +1106,16 @@ export default {
         difficulty_asc: 'Du plus facile au plus dur',
         name: 'Par nom',
         note: 'Par note'
-      }
+      },
+      randomRoute: 'Voie aléatoire',
+      randomRouteTitle: 'Tirer une voie au hasard',
+      randomRouteExplain: 'Choisissez une fourchette de cotations, nous vous proposerons une voie au hasard sur ce site.',
+      minGrade: 'Niveau mini',
+      maxGrade: 'Niveau maxi',
+      pickRandom: 'Tirer au sort',
+      pickAgain: 'Retirer au sort',
+      noRouteInRange: 'Aucune voie trouvée dans cette fourchette de niveaux.',
+      minMaxError: 'Le niveau mini doit être inférieur ou égal au niveau maxi.'
     },
     cragsTable: {
       crags: 'Sites',
@@ -1608,7 +1617,16 @@ export default {
         ascents_count: 'Trier par nombre de réalisations',
         likes_count: 'Trier par nombre de likes',
         comments_count: 'Trier par nombre de commentaires'
-      }
+      },
+      randomRoute: 'Ligne aléatoire',
+      randomRouteTitle: 'Tirer une ligne au hasard',
+      randomRouteExplain: 'Choisissez une fourchette de cotations, nous vous proposerons une ligne au hasard dans cet espace.',
+      minGrade: 'Niveau mini',
+      maxGrade: 'Niveau maxi',
+      pickRandom: 'Tirer au sort',
+      pickAgain: 'Retirer au sort',
+      noRouteInRange: 'Aucune ligne trouvée dans cette fourchette de niveaux.',
+      minMaxError: 'Le niveau mini doit être inférieur ou égal au niveau maxi.'
     },
     contest: {
       title: 'Les contests',


### PR DESCRIPTION
Ajoute un bouton « Voie aléatoire » sur la page des voies d'un site extérieur et un bouton dé dans les salles. L'utilisateur choisit un niveau mini/maxi, l'app charge les voies, filtre par grade_gap et propose une voie au hasard (avec bouton « retirer au sort »). Traductions FR/EN incluses